### PR TITLE
Additional Styling for Parent/Children selection

### DIFF
--- a/src/angular-multi-select.css
+++ b/src/angular-multi-select.css
@@ -132,8 +132,21 @@
 	content: '×';
 }
 
-.ams .ams_tick:before {
-	content: '✓'
+.ams .ams_tick:before,
+.ams .ams_group.ams_all_children_checked .ams_tick:before {
+  border: none;
+  color: #555;
+  content: '✓';
+  font-size: 10px;
+  padding: 0;
+}
+
+.ams .ams_group .ams_tick:before {
+  border: solid 1px #777;
+  color: #777;
+  content: '—';
+  font-size: 8px;
+  padding: 2px 3px;
 }
 
 .ams .ams_helper_btn.reset {

--- a/src/angular-multi-select.js
+++ b/src/angular-multi-select.js
@@ -565,6 +565,8 @@ angular_multi_select.directive('angularMultiSelect',
 					}
 					return true;
 				});
+				
+				item.allChecked = _total > 0 && _total === _checked;
 
 				return _total === _checked ? _checked : _checked > 0 ? -_checked : 0;
 			};

--- a/src/angular-multi-select.js
+++ b/src/angular-multi-select.js
@@ -1255,7 +1255,7 @@ angular_multi_select.run(['$templateCache', function($templateCache) {
 angular_multi_select.run(['$templateCache', function($templateCache) {
 	'use strict';
 	var template = "" +
-		"<div class='ams_item' ng-click='clickItem(item, true);' ng-class='{ams_selected: item[tickProperty], ams_group:_hasChildren(item, false) > 0, ams_focused: kbFocus[kbFocusIndex] === item[idProperty]}'>" +
+		"<div class='ams_item' ng-click='clickItem(item, true);' ng-class='{ams_selected: item[tickProperty], ams_all_children_checked: item.allChecked, ams_group:_hasChildren(item, false) > 0, ams_focused: kbFocus[kbFocusIndex] === item[idProperty]}'>" +
 			"<div ng-bind-html='_createItemLabel(item)'></div>" +
 			"<span class='ams_tick' ng-if='item[tickProperty] === true'></span>" +
 		"</div>" +


### PR DESCRIPTION
Added in the ability to change the icon/symbol being shown based on whether some or all child nodes were selected. This helps it give the 'indeterminate' effect of standard checkboxes.

Indeterminate Example:
https://css-tricks.com/indeterminate-checkboxes/

Screenshot of the change:
http://www.awesomescreenshot.com/image/731409/a6545884224041847d0772ea420374c7

Hope you don't mind the PRs. I was also going to extend this so to put the checkboxes on the left to be more like a traditional form and make it an option so you can easily toggle between left side or right side checkmarks.
