### PR TITLE
Added select_many() to exposed API

### DIFF
--- a/spec/angular-multi-select.spec.js
+++ b/spec/angular-multi-select.spec.js
@@ -346,17 +346,17 @@ describe('Testing directive button label customization and API', function() {
 		expect(item).toContainText("Chromium");
 	});
 
-  it('Should be able to select many items by their\'s IDs using the exposed API', function() {
-    timeout.flush();
-    element.scope().api.select_none();
-    timeout.flush();
+	it('Should be able to select many items by their\'s IDs using the exposed API', function() {
+		timeout.flush();
+		element.scope().api.select_none();
+		timeout.flush();
 
-    var ids = [41,42];
-    element.scope().api.select_many(ids);
-    timeout.flush();
+		var ids = [41,42];
+		element.scope().api.select_many(ids);
+		timeout.flush();
 
-    var items = $('.ams_item:not(.ams_group) > .ams_tick').prev();
-    expect(items).toContainText("Chromium");
-    expect(items).toContainText("Firefox");
-  });
+		var items = $('.ams_item:not(.ams_group) > .ams_tick').prev();
+		expect(items).toContainText("Chromium");
+		expect(items).toContainText("Firefox");
+	});
 });

--- a/spec/angular-multi-select.spec.js
+++ b/spec/angular-multi-select.spec.js
@@ -351,12 +351,12 @@ describe('Testing directive button label customization and API', function() {
     element.scope().api.select_none();
     timeout.flush();
 
-    var ids = [42,43];
+    var ids = [41,42];
     element.scope().api.select_many(ids);
     timeout.flush();
 
     var items = $('.ams_item:not(.ams_group) > .ams_tick').prev();
     expect(items).toContainText("Chromium");
-    expect(items).toContainText("Opera");
+    expect(items).toContainText("Firefox");
   });
 });

--- a/spec/angular-multi-select.spec.js
+++ b/spec/angular-multi-select.spec.js
@@ -345,4 +345,17 @@ describe('Testing directive button label customization and API', function() {
 		var item = $('.ams_item:not(.ams_group) > .ams_tick').prev();
 		expect(item).toContainText("Chromium");
 	});
+
+  it('Should be able to select many items by their\'s IDs using the exposed API', function() {
+    timeout.flush();
+    element.scope().api.select_none();
+    timeout.flush();
+
+    var ids = [42,43];
+
+    element.scope().api.select(ids);
+    timeout.flush();
+
+    expect('.ams_selected').toHaveLength(2);
+  });
 });

--- a/spec/angular-multi-select.spec.js
+++ b/spec/angular-multi-select.spec.js
@@ -352,10 +352,11 @@ describe('Testing directive button label customization and API', function() {
     timeout.flush();
 
     var ids = [42,43];
-
-    element.scope().api.select(ids);
+    element.scope().api.select_many(ids);
     timeout.flush();
 
-    expect('.ams_selected').toHaveLength(2);
+    var items = $('.ams_item:not(.ams_group) > .ams_tick').prev();
+    expect(items).toContainText("Chromium");
+    expect(items).toContainText("Opera");
   });
 });

--- a/spec/helpers/multi_selected.data.js
+++ b/spec/helpers/multi_selected.data.js
@@ -22,6 +22,7 @@ var multi_test_data = [
 				name: "Open Source",
 				sub: [
 					{
+						id: 41,
 						icon: '<img  src="https://cdn2.iconfinder.com/data/icons/humano2/32x32/apps/firefox-icon.png" />',
 						name: "Firefox",
 						check: true
@@ -32,7 +33,6 @@ var multi_test_data = [
 						name: "Chromium"
 					},
 					{
-            id: 43,
 						icon: '<img  src="https://cdn1.iconfinder.com/data/icons/logotypes/32/opera-32.png" />',
 						name: "Opera",
 						check: true

--- a/spec/helpers/multi_selected.data.js
+++ b/spec/helpers/multi_selected.data.js
@@ -32,6 +32,7 @@ var multi_test_data = [
 						name: "Chromium"
 					},
 					{
+            id: 43,
 						icon: '<img  src="https://cdn1.iconfinder.com/data/icons/logotypes/32/opera-32.png" />',
 						name: "Opera",
 						check: true

--- a/src/angular-multi-select.js
+++ b/src/angular-multi-select.js
@@ -135,16 +135,16 @@ angular_multi_select.directive('angularMultiSelect',
 							}
 						}, 0);
 					},
-          select_many: function (ids) {
-            $timeout(function() {
-              angular.forEach(ids, function (id) {
-                var item = $scope._getItemById(id);
-                if (item !== null && !$scope._isChecked(item)) {
-                  $scope.clickItem(item, true);
-                }
-              }, 0);
-            });
-          },
+					select_many: function (ids) {
+						$timeout(function() {
+							angular.forEach(ids, function (id) {
+								var item = $scope._getItemById(id);
+								if (item !== null && !$scope._isChecked(item)) {
+									$scope.clickItem(item, true);
+								}
+							}, 0);
+						});
+					},
 					reset: function() {
 						$timeout(function() {
 							$scope.reset();

--- a/src/angular-multi-select.js
+++ b/src/angular-multi-select.js
@@ -135,6 +135,16 @@ angular_multi_select.directive('angularMultiSelect',
 							}
 						}, 0);
 					},
+          select_many: function (ids) {
+            $timeout(function() {
+              angular.forEach(ids, function (id) {
+                var item = $scope._getItemById(id);
+                if (item !== null && !$scope._isChecked(item)) {
+                  $scope.clickItem(item, true);
+                }
+              }, 0);
+            });
+          },
 					reset: function() {
 						$timeout(function() {
 							$scope.reset();


### PR DESCRIPTION
Fixes #68

User should be able to select many items by theirs IDs:

``` javascript
var ids = ["Chrome","Safari"];
$scope.api.select_many(ids);
```

This way the api gets more flexible.

In my case I have different user roles like: `admin` , 'superAdmin', 'user' . Each has different set of permissions. 
So when new user has f.e. `admin` and `user` roles, their permissions are merged and call select_many(merged_ids)

Would be good if later `deselect()`, `deselect_many()` are implemented. 
Also to be configurable: when item is selected, whether parent to be checked or not. 
